### PR TITLE
[FEAT] 7주차 미션

### DIFF
--- a/src/main/java/com/example/umc/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/umc/domain/review/controller/ReviewController.java
@@ -3,6 +3,7 @@ package com.example.umc.domain.review.controller;
 import com.example.umc.domain.review.dto.ReviewResponseDto;
 import com.example.umc.domain.review.service.ReviewService;
 import com.example.umc.global.apiPayload.ApiResponse;
+import com.example.umc.global.apiPayload.code.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -32,6 +33,8 @@ public class ReviewController {
         .stream()
         .map(ReviewResponseDto::from)
         .collect(Collectors.toList());
-    return ApiResponse.onSuccess(reviews);
+
+    SuccessStatus code = SuccessStatus._OK;
+    return ApiResponse.onSuccess(code, reviews);
   }
 }

--- a/src/main/java/com/example/umc/domain/test/controller/TestController.java
+++ b/src/main/java/com/example/umc/domain/test/controller/TestController.java
@@ -1,0 +1,40 @@
+package com.example.umc.domain.test.controller;
+
+import com.example.umc.domain.test.converter.TestConverter;
+import com.example.umc.domain.test.dto.TestResDTO;
+import com.example.umc.domain.test.service.TestQueryService;
+import com.example.umc.global.apiPayload.ApiResponse;
+import com.example.umc.global.apiPayload.code.status.SuccessStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/temp")
+public class TestController {
+
+  private final TestQueryService testQueryService;
+
+  @GetMapping("/test")
+  public ApiResponse<TestResDTO.Testing> test() {
+    // 응답 코드 정의
+    SuccessStatus code = SuccessStatus._OK;
+
+    return ApiResponse.onSuccess(
+        code,
+        TestConverter.toTestingDTO("This is Test!"));
+  }
+
+  // 예외 상황
+  @GetMapping("/exception")
+  public ApiResponse<TestResDTO.Exception> exception(@RequestParam Long flag) {
+    testQueryService.checkFlag(flag);
+
+    // 응답 코드 정의
+    SuccessStatus code = SuccessStatus._OK;
+    return ApiResponse.onSuccess(code, TestConverter.toExceptionDTO("This is Test!"));
+  }
+}

--- a/src/main/java/com/example/umc/domain/test/converter/TestConverter.java
+++ b/src/main/java/com/example/umc/domain/test/converter/TestConverter.java
@@ -1,0 +1,20 @@
+package com.example.umc.domain.test.converter;
+
+import com.example.umc.domain.test.dto.TestResDTO;
+
+public class TestConverter {
+
+  // 객체 -> DTO
+  public static TestResDTO.Testing toTestingDTO(String testing) {
+    return TestResDTO.Testing.builder()
+        .testString(testing)
+        .build();
+  }
+
+  // 객체 -> DTO
+  public static TestResDTO.Exception toExceptionDTO(String testing) {
+    return TestResDTO.Exception.builder()
+        .testString(testing)
+        .build();
+  }
+}

--- a/src/main/java/com/example/umc/domain/test/dto/TestResDTO.java
+++ b/src/main/java/com/example/umc/domain/test/dto/TestResDTO.java
@@ -1,0 +1,19 @@
+package com.example.umc.domain.test.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class TestResDTO {
+
+  @Builder
+  @Getter
+  public static class Testing {
+    private String testString;
+  }
+
+  @Builder
+  @Getter
+  public static class Exception {
+    private String testString;
+  }
+}

--- a/src/main/java/com/example/umc/domain/test/exception/TestException.java
+++ b/src/main/java/com/example/umc/domain/test/exception/TestException.java
@@ -1,0 +1,10 @@
+package com.example.umc.domain.test.exception;
+
+import com.example.umc.global.exception.GeneralException;
+
+public class TestException extends GeneralException {
+
+  public TestException(com.example.umc.domain.test.exception.code.TestErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/com/example/umc/domain/test/exception/code/TestErrorCode.java
+++ b/src/main/java/com/example/umc/domain/test/exception/code/TestErrorCode.java
@@ -1,0 +1,39 @@
+package com.example.umc.domain.test.exception.code;
+
+import com.example.umc.global.apiPayload.code.BaseErrorCode;
+import com.example.umc.global.apiPayload.code.ErrorReasonDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum TestErrorCode implements BaseErrorCode {
+
+  // For test
+  TEST_EXCEPTION(HttpStatus.BAD_REQUEST, "TEST400_1", "이거는 테스트"),
+  ;
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+
+  @Override
+  public ErrorReasonDto getReason() {
+    return ErrorReasonDto.builder()
+        .message(message)
+        .code(code)
+        .isSuccess(false)
+        .build();
+  }
+
+  @Override
+  public ErrorReasonDto getReasonHttpStatus() {
+    return ErrorReasonDto.builder()
+        .httpStatus(httpStatus)
+        .message(message)
+        .code(code)
+        .isSuccess(false)
+        .build();
+  }
+}

--- a/src/main/java/com/example/umc/domain/test/service/TestQueryService.java
+++ b/src/main/java/com/example/umc/domain/test/service/TestQueryService.java
@@ -1,0 +1,5 @@
+package com.example.umc.domain.test.service;
+
+public interface TestQueryService {
+  void checkFlag(Long flag);
+}

--- a/src/main/java/com/example/umc/domain/test/service/TestQueryServiceImpl.java
+++ b/src/main/java/com/example/umc/domain/test/service/TestQueryServiceImpl.java
@@ -1,0 +1,18 @@
+package com.example.umc.domain.test.service;
+
+import com.example.umc.domain.test.exception.TestException;
+import com.example.umc.domain.test.exception.code.TestErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TestQueryServiceImpl implements TestQueryService {
+
+  @Override
+  public void checkFlag(Long flag) {
+    if (flag == 1) {
+      throw new TestException(TestErrorCode.TEST_EXCEPTION);
+    }
+  }
+}

--- a/src/main/java/com/example/umc/global/apiPayload/ApiResponse.java
+++ b/src/main/java/com/example/umc/global/apiPayload/ApiResponse.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+@JsonPropertyOrder({ "isSuccess", "code", "message", "result" })
 public class ApiResponse<T> {
   @JsonProperty("isSuccess")
   private final boolean isSuccess;
@@ -25,8 +25,15 @@ public class ApiResponse<T> {
         true,
         SuccessStatus._OK.getCode(),
         SuccessStatus._OK.getMessage(),
-        result
-    );
+        result);
+  }
+
+  public static <T> ApiResponse<T> onSuccess(BaseCode code, T result) {
+    return new ApiResponse<>(
+        true,
+        code.getReasonHttpStatus().getCode(),
+        code.getReasonHttpStatus().getMessage(),
+        result);
   }
 
   public static <T> ApiResponse<T> of(BaseCode code, String message, T result) {
@@ -34,8 +41,7 @@ public class ApiResponse<T> {
         true,
         code.getReasonHttpStatus().getCode(),
         code.getReasonHttpStatus().getMessage(),
-        result
-    );
+        result);
   }
 
   public static <T> ApiResponse<T> onFailure(String code, String message, T result) {

--- a/src/main/java/com/example/umc/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/example/umc/global/apiPayload/code/status/SuccessStatus.java
@@ -9,8 +9,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum SuccessStatus implements BaseCode {
-  _OK(HttpStatus.OK, "COMMON2000", "성공입니다."),
+  _OK(HttpStatus.OK, "COMMON200", "성공적으로 요청을 처리했습니다."),
   ;
+
   private final HttpStatus httpStatus;
   private final String code;
   private final String message;

--- a/src/main/java/com/example/umc/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/umc/global/config/SecurityConfig.java
@@ -18,6 +18,7 @@ public class SecurityConfig {
         .authorizeHttpRequests(authz -> authz
             // API 경로 허용
             .requestMatchers("/api/v1/reviews/**").permitAll()
+            .requestMatchers("/temp/**").permitAll()
             .requestMatchers("/swagger-ui/**").permitAll()
             .requestMatchers("/v3/api-docs/**").permitAll()
             .requestMatchers("/swagger-ui.html").permitAll()

--- a/src/main/java/com/example/umc/global/exception/GeneralException.java
+++ b/src/main/java/com/example/umc/global/exception/GeneralException.java
@@ -1,0 +1,15 @@
+package com.example.umc.global.exception;
+
+import com.example.umc.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+
+@Getter
+public class GeneralException extends RuntimeException {
+
+  private BaseErrorCode codeBase;
+
+  public GeneralException(BaseErrorCode codeBase) {
+    super(codeBase.getReason().getMessage());
+    this.codeBase = codeBase;
+  }
+}

--- a/src/main/java/com/example/umc/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/umc/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,92 @@
+package com.example.umc.global.exception;
+
+import com.example.umc.global.apiPayload.ApiResponse;
+import com.example.umc.global.apiPayload.code.ErrorReasonDto;
+import com.example.umc.global.apiPayload.code.status.ErrorStatus;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+  @ExceptionHandler
+  public ResponseEntity<Object> general(GeneralException e, WebRequest request) {
+    ErrorReasonDto reasonHttpStatus = e.getCodeBase().getReasonHttpStatus();
+    return handleExceptionInternal(e, reasonHttpStatus, HttpHeaders.EMPTY, reasonHttpStatus.getHttpStatus(), request);
+  }
+
+  @ExceptionHandler
+  public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+    return handleExceptionInternalFalse(e,
+        ApiResponse.onFailure(
+            ErrorStatus._INTERNAL_SERVER_ERROR.getReasonHttpStatus().getCode(),
+            ErrorStatus._INTERNAL_SERVER_ERROR.getReasonHttpStatus().getMessage(),
+            null),
+        HttpHeaders.EMPTY, HttpStatus.INTERNAL_SERVER_ERROR, request, e.getMessage());
+  }
+
+  @Override
+  public ResponseEntity<Object> handleMethodArgumentNotValid(
+      MethodArgumentNotValidException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+    Map<String, String> errors = new LinkedHashMap<>();
+
+    e.getBindingResult().getFieldErrors().stream()
+        .forEach(fieldError -> {
+          String fieldName = fieldError.getField();
+          String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+          errors.merge(fieldName, errorMessage, (existingMessage, newMessage) -> existingMessage + ", " + newMessage);
+        });
+
+    return handleExceptionInternalArgs(e, HttpHeaders.EMPTY, errors, HttpStatus.BAD_REQUEST, request);
+  }
+
+  @ExceptionHandler
+  public ResponseEntity<Object> handleConstraintViolationException(ConstraintViolationException e, WebRequest request) {
+    String errorMessage = e.getConstraintViolations().stream()
+        .map(constraintViolation -> constraintViolation.getMessage())
+        .findFirst()
+        .orElseThrow(() -> new RuntimeException("ConstraintViolationException translating unexpected"));
+
+    return handleExceptionInternalFalse(e, null, HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, request, errorMessage);
+  }
+
+  protected ResponseEntity<Object> handleExceptionInternal(Exception e, Object body,
+      HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
+
+    return handleExceptionInternalFalse(e, ApiResponse.onFailure(
+        ((ErrorReasonDto) body).getCode(),
+        ((ErrorReasonDto) body).getMessage(),
+        null), headers, statusCode, request, ((ErrorReasonDto) body).getMessage());
+  }
+
+  private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers,
+      Map<String, String> errors,
+      HttpStatusCode statusCode, WebRequest request) {
+    return handleExceptionInternalFalse(e, ApiResponse.onFailure("COMMON400", "잘못된 요청입니다.", errors), headers,
+        statusCode, request, errors.toString());
+  }
+
+  private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, Object body,
+      HttpHeaders headers, HttpStatusCode statusCode, WebRequest request, String errorPoint) {
+    ServletWebRequest servletWebRequest = (ServletWebRequest) request;
+    String url = servletWebRequest.getRequest().getRequestURI();
+    log.error("Rest API Exception: {}, url: {}, message: {}", statusCode, url, errorPoint, e);
+
+    return super.handleExceptionInternal(e, body, headers, statusCode, request);
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,3 @@
 spring.application.name=umc
 spring.profiles.active=dev
-spring.config.import=optional:file:./BEConfig/application.properties,optional:file:./BEConfig/application-dev.properties,optional:file:./BEConfig/application-test.properties,optional:file:./BEConfig/application-prod.properties
+spring.config.import=optional:file:./BEConfig/application.properties,optional:file:./BEConfig/application-dev.properties


### PR DESCRIPTION
### 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
closed #8 

### 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
### 관련 이슈

<!-- 관련 이슈를 적어주세요 -->

### 작업한 내용

<!-- 작업한 내용을 적어주세요 -->

#### 1. 전역 예외 처리 시스템 구현

- **GlobalExceptionHandler** (`@RestControllerAdvice`): 모든 예외를 통일된 형식으로 처리
  - `GeneralException`: 커스텀 비즈니스 예외 처리
  - `MethodArgumentNotValidException`: `@Valid` 검증 실패 처리
  - `ConstraintViolationException`: 제약 조건 위반 처리
  - `Exception`: 일반 예외 처리 (500 에러)

- **GeneralException**: `BaseErrorCode`를 사용하는 커스텀 예외 클래스

#### 2. 도메인별 예외 처리 실습 구현

- **TestErrorCode**: 테스트용 에러 코드 enum (`TEST_EXCEPTION`)
- **TestException**: `GeneralException`을 상속한 도메인별 예외 클래스
- **TestController**: 
  - `GET /temp/test`: 정상 응답 테스트
  - `GET /temp/exception?flag=1`: 예외 발생 테스트
- **TestQueryService**: `flag == 1`일 때 예외 발생 로직

#### 3. API 응답 통일 처리

- **ApiResponse 개선**: 
  - `onSuccess(BaseCode code, T result)` 메서드 추가 (워크북 패턴)
  - BaseCode를 직접 전달하여 일관된 응답 보장
- **SuccessStatus 수정**:
  - 코드: `"COMMON2000"` → `"COMMON200"`
  - 메시지: `"성공입니다."` → `"성공적으로 요청을 처리했습니다."`
- **모든 Controller에 워크북 패턴 적용**:
  - `ReviewController`, `TestController`에서 `SuccessStatus code = SuccessStatus._OK` 사용

#### 4. 보안 및 설정 파일 정리

- **SecurityConfig**: `/temp/**` 경로 허용 추가
- **프로파일 설정 정리**:
  - `application.properties`: `prod` 설정 파일 제거 (dev 프로파일 기본 사용)
  - `application-test.properties`, `application-prod.properties`: `spring.profiles.active` 주석 처리

### PR Point 및 참고사항, 스크린샷

#### 핵심 구현 사항

1. **예외 처리 흐름**:
   ```
   Service에서 예외 발생 → TestException 생성 → GeneralException 상속 
   → GlobalExceptionHandler가 감지 → ApiResponse 형식으로 통일된 에러 응답
   ```

2. **응답 통일 패턴**:
   - 성공: `ApiResponse.onSuccess(code, result)`
   - 실패: `GlobalExceptionHandler`가 자동으로 `ApiResponse.onFailure()` 형식으로 변환

#### 주요 파일

- `GlobalExceptionHandler.java`: 전역 예외 처리 핵심 로직
- `GeneralException.java`: 커스텀 예외 기본 클래스
- `TestException.java`, `TestErrorCode.java`: 도메인별 예외 처리 예시
- `ApiResponse.java`: 응답 통일 래퍼 클래스
- `SecurityConfig.java`: `/temp/**` 경로 접근 허용

### PR Point 및 참고사항, 스크린샷
<img width="732" height="570" alt="스크린샷 2025-11-03 오전 2 45 00" src="https://github.com/user-attachments/assets/77889a49-7958-4560-b67e-b74a9e3c84e7" />
<img width="736" height="510" alt="스크린샷 2025-11-03 오전 2 45 09" src="https://github.com/user-attachments/assets/acccb6c0-25b0-4891-a162-282ecc32930d" />



<details>
<summary>@RestControllerAdvice의 장점과 필요성</summary>
# @RestControllerAdvice의 장점과 필요성

## @RestControllerAdvice란?

`@RestControllerAdvice`는 Spring에서 전역적으로 예외를 처리하고 응답을 통일하기 위한 어노테이션
- `@ControllerAdvice` + `@ResponseBody`의 결합
- 모든 `@RestController`에서 발생하는 예외를 한 곳에서 처리

---

## @RestControllerAdvice의 장점

### 1. **전역 예외 처리**
모든 Controller에서 발생하는 예외를 한 곳에서 처리할 수 있음

```java
@RestControllerAdvice
public class GlobalExceptionHandler {
    
    @ExceptionHandler(GeneralException.class)
    public ResponseEntity<Object> handleGeneralException(GeneralException e) {
        // 모든 Controller의 GeneralException을 여기서 처리
        return ResponseEntity
            .status(e.getCodeBase().getReasonHttpStatus().getHttpStatus())
            .body(ApiResponse.onFailure(
                e.getCodeBase().getCode(),
                e.getCodeBase().getMessage(),
                null
            ));
    }
}
```

**장점:**
- 각 Controller마다 try-catch 블록을 작성할 필요가 없음
- 예외 처리 로직이 한 곳에 집중되어 유지보수 용이

---

### 2. **코드 중복 제거**

#### RestControllerAdvice 없을 때
```java
@RestController
public class UserController {
    
    @GetMapping("/users/{id}")
    public ResponseEntity<?> getUser(@PathVariable Long id) {
        try {
            User user = userService.findById(id);
            return ResponseEntity.ok(user);
        } catch (UserNotFoundException e) {
            return ResponseEntity
                .status(HttpStatus.NOT_FOUND)
                .body(new ErrorResponse("USER404", "사용자를 찾을 수 없습니다."));
        } catch (Exception e) {
            return ResponseEntity
                .status(HttpStatus.INTERNAL_SERVER_ERROR)
                .body(new ErrorResponse("COMMON500", "서버 에러"));
        }
    }
    
    @PostMapping("/users")
    public ResponseEntity<?> createUser(@RequestBody UserDto dto) {
        try {
            User user = userService.create(dto);
            return ResponseEntity.ok(user);
        } catch (DuplicateUserException e) {
            return ResponseEntity
                .status(HttpStatus.BAD_REQUEST)
                .body(new ErrorResponse("USER400", "중복된 사용자"));
        } catch (Exception e) {
            return ResponseEntity
                .status(HttpStatus.INTERNAL_SERVER_ERROR)
                .body(new ErrorResponse("COMMON500", "서버 에러"));
        }
    }
    
    // 모든 메서드마다 동일한 try-catch 반복...
}
```

#### RestControllerAdvice 있을 때
```java
@RestController
public class UserController {
    
    @GetMapping("/users/{id}")
    public ResponseEntity<User> getUser(@PathVariable Long id) {
        // 예외는 GlobalExceptionHandler가 처리
        User user = userService.findById(id);
        return ResponseEntity.ok(user);
    }
    
    @PostMapping("/users")
    public ResponseEntity<User> createUser(@RequestBody UserDto dto) {
        // 예외는 GlobalExceptionHandler가 처리
        User user = userService.create(dto);
        return ResponseEntity.ok(user);
    }
}

@RestControllerAdvice
public class GlobalExceptionHandler {
    
    @ExceptionHandler(UserNotFoundException.class)
    public ResponseEntity<?> handleUserNotFound(UserNotFoundException e) {
        return ResponseEntity
            .status(HttpStatus.NOT_FOUND)
            .body(new ErrorResponse("USER404", e.getMessage()));
    }
    
    @ExceptionHandler(DuplicateUserException.class)
    public ResponseEntity<?> handleDuplicate(DuplicateUserException e) {
        return ResponseEntity
            .status(HttpStatus.BAD_REQUEST)
            .body(new ErrorResponse("USER400", e.getMessage()));
    }
    
    @ExceptionHandler(Exception.class)
    public ResponseEntity<?> handleGeneral(Exception e) {
        return ResponseEntity
            .status(HttpStatus.INTERNAL_SERVER_ERROR)
            .body(new ErrorResponse("COMMON500", "서버 에러"));
    }
}
```

---

### 3. **일관된 응답 형식 보장**

모든 에러 응답이 동일한 형식으로 통일

```java
@RestControllerAdvice
public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
    
    @ExceptionHandler(GeneralException.class)
    public ResponseEntity<Object> general(GeneralException e, WebRequest request) {
        // 모든 에러를 ApiResponse 형식으로 통일
        return ResponseEntity
            .status(e.getCodeBase().getReasonHttpStatus().getHttpStatus())
            .body(ApiResponse.onFailure(
                e.getCodeBase().getCode(),
                e.getCodeBase().getMessage(),
                null
            ));
    }
}
```

**응답 예시:**
```json
{
  "isSuccess": false,
  "code": "TEST400_1",
  "message": "이거는 테스트",
  "result": null
}
```

**장점:**
- 프론트엔드에서 에러 처리 로직 단순화
- API 문서화 용이
- 클라이언트 개발자와의 협업 효율 증가

---

### 4. **관심사의 분리 (Separation of Concerns)**

- **Controller**: 비즈니스 로직 흐름에만 집중
- **Service**: 실제 비즈니스 로직 처리
- **ExceptionHandler**: 예외 처리 및 에러 응답 생성

```java
// Controller - 비즈니스 흐름만 집중
@GetMapping("/exception")
public ApiResponse<TestResDTO.Exception> exception(@RequestParam Long flag) {
    testQueryService.checkFlag(flag);  // 예외 발생 가능
    return ApiResponse.onSuccess(code, TestConverter.toExceptionDTO("This is Test!"));
}

// Service - 비즈니스 로직만 집중
@Override
public void checkFlag(Long flag) {
    if (flag == 1) {
        throw new TestException(TestErrorCode.TEST_EXCEPTION);  // 예외 던지기만
    }
}

// ExceptionHandler - 예외 처리만 집중
@ExceptionHandler
public ResponseEntity<Object> general(GeneralException e, WebRequest request) {
    ErrorReasonDto reasonHttpStatus = e.getCodeBase().getReasonHttpStatus();
    return handleExceptionInternal(e, reasonHttpStatus, HttpHeaders.EMPTY, 
        reasonHttpStatus.getHttpStatus(), request);
}
```

---

### 5. **다양한 예외 타입 통합 처리**

여러 종류의 예외를 체계적으로 처리할 수 있음

```java
@RestControllerAdvice
public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
    
    // 1. 커스텀 예외 처리
    @ExceptionHandler(GeneralException.class)
    public ResponseEntity<Object> general(GeneralException e, WebRequest request) {
        // ...
    }
    
    // 2. Validation 예외 처리 (@Valid 실패)
    @Override
    public ResponseEntity<Object> handleMethodArgumentNotValid(
            MethodArgumentNotValidException e, HttpHeaders headers, 
            HttpStatusCode status, WebRequest request) {
        Map<String, String> errors = new LinkedHashMap<>();
        e.getBindingResult().getFieldErrors().forEach(fieldError -> {
            errors.merge(fieldError.getField(), 
                fieldError.getDefaultMessage(), 
                (existing, newMsg) -> existing + ", " + newMsg);
        });
        return handleExceptionInternalArgs(e, HttpHeaders.EMPTY, errors, 
            HttpStatus.BAD_REQUEST, request);
    }
    
    // 3. 제약 조건 위반 처리
    @ExceptionHandler
    public ResponseEntity<Object> handleConstraintViolation(
            ConstraintViolationException e, WebRequest request) {
        String errorMessage = e.getConstraintViolations().stream()
            .map(cv -> cv.getMessage())
            .findFirst()
            .orElseThrow();
        return handleExceptionInternalFalse(e, null, HttpHeaders.EMPTY, 
            HttpStatus.BAD_REQUEST, request, errorMessage);
    }
    
    // 4. 일반 예외 처리 (모든 예외 catch)
    @ExceptionHandler
    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
        return handleExceptionInternalFalse(e,
            ApiResponse.onFailure("COMMON500", "서버 에러", null),
            HttpHeaders.EMPTY, HttpStatus.INTERNAL_SERVER_ERROR, 
            request, e.getMessage());
    }
}
```

---

### 6. **로깅 및 모니터링 통합**

예외 처리 시 일관된 로깅을 적용할 수 있음

```java
@RestControllerAdvice
public class GlobalExceptionHandler {
    
    private ResponseEntity<Object> handleExceptionInternalFalse(
            Exception e, Object body, HttpHeaders headers, 
            HttpStatusCode statusCode, WebRequest request, String errorPoint) {
        
        ServletWebRequest servletWebRequest = (ServletWebRequest) request;
        String url = servletWebRequest.getRequest().getRequestURI();
        
        // 통합 로깅
        log.error("Rest API Exception: {}, url: {}, message: {}", 
            statusCode, url, errorPoint, e);
        
        return super.handleExceptionInternal(e, body, headers, statusCode, request);
    }
}
```

---

## @RestControllerAdvice 없을 경우의 불편함

### 1. **코드 중복**
```java
// Controller 1
@RestController
public class UserController {
    @GetMapping("/users")
    public ResponseEntity<?> getUsers() {
        try {
            // 로직
        } catch (Exception e) {
            // 동일한 예외 처리 코드
        }
    }
}

// Controller 2
@RestController
public class OrderController {
    @GetMapping("/orders")
    public ResponseEntity<?> getOrders() {
        try {
            // 로직
        } catch (Exception e) {
            // 또 동일한 예외 처리 코드
        }
    }
}

// Controller 3...
// 무한 반복...
```

**문제점:**
- 100개의 API가 있다면 100번 동일한 코드 작성
- 예외 처리 로직 수정 시 모든 Controller 수정 필요
- 유지보수 비용 증가

---

### 2. **일관성 없는 에러 응답**

각 개발자마다 다른 형식으로 에러를 반환할 수 있음

```java
// 개발자 A
return ResponseEntity.status(400).body(Map.of("error", "잘못된 요청"));

// 개발자 B
return ResponseEntity.badRequest().body(new ErrorDto("400", "Bad Request"));

// 개발자 C
return new ResponseEntity<>(new Error("에러 발생"), HttpStatus.BAD_REQUEST);
```

**결과:**
```json
// 응답 1
{ "error": "잘못된 요청" }

// 응답 2
{ "code": "400", "message": "Bad Request" }

// 응답 3
{ "errorMessage": "에러 발생" }
```

**문제점:**
- 프론트엔드에서 각기 다른 에러 형식 처리 필요
- API 문서화 어려움
- 클라이언트 개발자 혼란

---

### 3. **비즈니스 로직과 예외 처리 혼재**

Controller가 복잡해지고 가독성이 떨어짐

```java
@RestController
public class OrderController {
    
    @PostMapping("/orders")
    public ResponseEntity<?> createOrder(@RequestBody OrderDto dto) {
        try {
            // 비즈니스 로직
            Order order = orderService.create(dto);
            
            try {
                paymentService.process(order);
            } catch (PaymentException e) {
                // 결제 예외 처리
                return ResponseEntity.status(402)
                    .body(Map.of("error", "결제 실패"));
            }
            
            try {
                notificationService.send(order);
            } catch (NotificationException e) {
                // 알림 예외는 무시
                log.warn("알림 전송 실패: {}", e.getMessage());
            }
            
            return ResponseEntity.ok(order);
            
        } catch (InsufficientStockException e) {
            return ResponseEntity.status(409)
                .body(Map.of("error", "재고 부족"));
        } catch (InvalidOrderException e) {
            return ResponseEntity.badRequest()
                .body(Map.of("error", e.getMessage()));
        } catch (Exception e) {
            log.error("주문 생성 실패", e);
            return ResponseEntity.status(500)
                .body(Map.of("error", "서버 에러"));
        }
    }
}
```

**문제점:**
- 실제 비즈니스 로직이 예외 처리 코드에 묻힘
- 가독성 극도로 저하
- 테스트 코드 작성 어려움

---

### 4. **예외 처리 누락 위험**

```java
@GetMapping("/users/{id}")
public ResponseEntity<User> getUser(@PathVariable Long id) {
    // 예외 처리를 깜빡함!
    User user = userService.findById(id);  // UserNotFoundException 발생 가능
    return ResponseEntity.ok(user);
}
```

**결과:**
```json
// 500 Internal Server Error와 함께 스택 트레이스 노출
{
  "timestamp": "2025-11-02T12:34:56.789+00:00",
  "status": 500,
  "error": "Internal Server Error",
  "trace": "com.example.exception.UserNotFoundException: User not found\n\tat com.example...",
  "message": "User not found",
  "path": "/users/999"
}
```

**문제점:**
- 보안에 취약 (스택 트레이스 노출)
- 클라이언트가 예상하지 못한 응답 형식
- 프로덕션 환경에서 디버깅 정보 노출

---

### 5. **변경 비용 증가**

에러 응답 형식을 변경하려면?

```java
// 기존: { "error": "message" }
// 변경: { "isSuccess": false, "code": "...", "message": "...", "result": null }

// RestControllerAdvice 없으면 → 모든 Controller 수정 필요
// RestControllerAdvice 있으면 → GlobalExceptionHandler만 수정
```

---

## 실전 비교 예시

### 시나리오: 사용자 조회 API

#### Without @RestControllerAdvice
```java
@RestController
public class UserController {
    
    @GetMapping("/users/{id}")
    public ResponseEntity<?> getUser(@PathVariable Long id) {
        try {
            // 1. 입력 검증
            if (id <= 0) {
                return ResponseEntity.badRequest()
                    .body(Map.of("error", "유효하지 않은 ID"));
            }
            
            // 2. 비즈니스 로직
            try {
                User user = userService.findById(id);
                return ResponseEntity.ok(user);
            } catch (UserNotFoundException e) {
                return ResponseEntity.status(HttpStatus.NOT_FOUND)
                    .body(Map.of("code", "USER404", "message", "사용자를 찾을 수 없습니다."));
            } catch (DatabaseException e) {
                log.error("DB 에러: {}", e.getMessage());
                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                    .body(Map.of("error", "데이터베이스 에러"));
            }
            
        } catch (Exception e) {
            log.error("예상치 못한 에러", e);
            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                .body(Map.of("error", "서버 에러가 발생했습니다."));
        }
    }
}
```

#### With @RestControllerAdvice
```java
@RestController
public class UserController {
    
    @GetMapping("/users/{id}")
    public ApiResponse<User> getUser(@PathVariable Long id) {
        // 비즈니스 로직만 집중
        User user = userService.findById(id);
        return ApiResponse.onSuccess(user);
    }
}

@RestControllerAdvice
public class GlobalExceptionHandler {
    
    @ExceptionHandler(UserNotFoundException.class)
    public ResponseEntity<Object> handleUserNotFound(UserNotFoundException e, WebRequest request) {
        return handleExceptionInternal(e, 
            ErrorStatus.USER_NOT_FOUND.getReasonHttpStatus(),
            HttpHeaders.EMPTY, 
            HttpStatus.NOT_FOUND, 
            request);
    }
    
    @ExceptionHandler(DatabaseException.class)
    public ResponseEntity<Object> handleDatabase(DatabaseException e, WebRequest request) {
        log.error("DB 에러: {}", e.getMessage());
        return handleExceptionInternal(e,
            ErrorStatus.DATABASE_ERROR.getReasonHttpStatus(),
            HttpHeaders.EMPTY,
            HttpStatus.INTERNAL_SERVER_ERROR,
            request);
    }
    
    @ExceptionHandler(Exception.class)
    public ResponseEntity<Object> handleGeneral(Exception e, WebRequest request) {
        log.error("예상치 못한 에러", e);
        return handleExceptionInternal(e,
            ErrorStatus._INTERNAL_SERVER_ERROR.getReasonHttpStatus(),
            HttpHeaders.EMPTY,
            HttpStatus.INTERNAL_SERVER_ERROR,
            request);
    }
}
```

---

## 결론

`@RestControllerAdvice`는 단순한 편의 기능이 아니라, **프로덕션 수준의 API 개발에 필수적인 아키텍처 패턴**

**핵심 가치:**
1. 코드 중복 제거 → 개발 생산성 향상
2. 일관된 응답 형식 → 클라이언트 개발 편의성 향상
3. 관심사의 분리 → 코드 품질 및 유지보수성 향상
4. 전역 예외 처리 → 안정성 및 보안성 향상
</details>

