### PR TITLE
feat: 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,11 +54,21 @@ dependencies {
 	testImplementation 'org.mockito:mockito-inline:5.2.0'
 
 	// QueryDSL : OpenFeign
-    implementation "io.github.openfeign.querydsl:querydsl-jpa:7.0"
-    implementation "io.github.openfeign.querydsl:querydsl-core:7.0"
-    annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:7.0:jpa"
-    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
-    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+  implementation "io.github.openfeign.querydsl:querydsl-jpa:7.0"
+  implementation "io.github.openfeign.querydsl:querydsl-core:7.0"
+  annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:7.0:jpa"
+  annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+  annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+
+	// Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
+
+	// Jwt
+  implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+  implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+  implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+implementation 'org.springframework.boot:spring-boot-configuration-processor'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/umc/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/umc/domain/member/controller/MemberController.java
@@ -23,9 +23,17 @@ public class MemberController {
     @PostMapping("/signup")
     @Operation(summary = "회원가입", description = "새로운 회원을 등록합니다.")
     public ApiResponse<MemberResDTO.JoinDTO> signUp(
-            @RequestBody @Valid MemberReqDTO.JoinDTO dto
-    ) {
+            @RequestBody @Valid MemberReqDTO.JoinDTO dto) {
         MemberResDTO.JoinDTO response = memberCommandService.signup(dto);
         return ApiResponse.onSuccess(MemberSuccessCode.MEMBER_CREATED, response);
+    }
+
+    // 로그인
+    @PostMapping("/login")
+    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")
+    public ApiResponse<MemberResDTO.LoginDTO> login(
+            @RequestBody @Valid MemberReqDTO.LoginDTO dto) {
+        MemberResDTO.LoginDTO response = memberCommandService.login(dto);
+        return ApiResponse.onSuccess(MemberSuccessCode.MEMBER_LOGIN_SUCCESS, response);
     }
 }

--- a/src/main/java/com/example/umc/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/example/umc/domain/member/converter/MemberConverter.java
@@ -3,6 +3,7 @@ package com.example.umc.domain.member.converter;
 import com.example.umc.domain.member.dto.MemberReqDTO;
 import com.example.umc.domain.member.dto.MemberResDTO;
 import com.example.umc.domain.user.entity.User;
+import com.example.umc.global.auth.Role;
 
 public class MemberConverter {
 
@@ -14,12 +15,41 @@ public class MemberConverter {
                 .build();
     }
 
+    // Entity -> LoginDTO
+    /*
+    public static MemberResDTO.LoginDTO toLoginDTO(User member) {
+        return MemberResDTO.LoginDTO.builder()
+                .memberId(member.getUserId())
+                .email(member.getEmail())
+                .name(member.getName())
+                .role(member.getRole())
+                .createdAt(member.getCreatedAt())
+                .build();
+    }
+    */
+
+    // Entity + AccessToken -> LoginDTO
+    public static MemberResDTO.LoginDTO toLoginDTO(User member, String accessToken) {
+        return MemberResDTO.LoginDTO.builder()
+                .memberId(member.getUserId())
+                .email(member.getEmail())
+                .name(member.getName())
+                .role(member.getRole())
+                .accessToken(accessToken)
+                .createdAt(member.getCreatedAt())
+                .build();
+    }
+
     // DTO -> Entity
-    public static User toMember(MemberReqDTO.JoinDTO dto) {
+    public static User toMember(MemberReqDTO.JoinDTO dto, String salt, Role role) {
         return User.builder()
                 .name(dto.name())
                 .birth(dto.birth())
                 .address(dto.address() != null ? dto.address().toString() : null)
+                .password(salt)
+                .role(dto.role())
+                .email(dto.email())
+                .address(dto.address())
                 .gender(dto.gender())
                 .build();
     }

--- a/src/main/java/com/example/umc/domain/member/dto/MemberReqDTO.java
+++ b/src/main/java/com/example/umc/domain/member/dto/MemberReqDTO.java
@@ -1,6 +1,7 @@
 package com.example.umc.domain.member.dto;
 
 import com.example.umc.domain.user.enums.Gender;
+import com.example.umc.global.auth.Role;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -10,8 +11,16 @@ public class MemberReqDTO {
             String name,
             Gender gender,
             LocalDate birth,
+            String password,
+            String email,
+            Role role,
             String address,
             String specAddress,
-            List<Long> preferCategory
-    ) {}
+            List<Long> preferCategory) {
+    }
+
+    public record LoginDTO(
+            String email,
+            String password) {
+    }
 }

--- a/src/main/java/com/example/umc/domain/member/dto/MemberResDTO.java
+++ b/src/main/java/com/example/umc/domain/member/dto/MemberResDTO.java
@@ -1,5 +1,6 @@
 package com.example.umc.domain.member.dto;
 
+import com.example.umc.global.auth.Role;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -8,6 +9,16 @@ public class MemberResDTO {
     @Builder
     public record JoinDTO(
             Long memberId,
-            LocalDateTime createdAt
-    ) {}
+            LocalDateTime createdAt) {
+    }
+
+    @Builder
+    public record LoginDTO(
+            Long memberId,
+            String email,
+            String name,
+            Role role,
+            String accessToken,
+            LocalDateTime createdAt) {
+    }
 }

--- a/src/main/java/com/example/umc/domain/member/exception/code/MemberErrorCode.java
+++ b/src/main/java/com/example/umc/domain/member/exception/code/MemberErrorCode.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 public enum MemberErrorCode implements BaseErrorCode {
 
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404_1", "해당 사용자를 찾지 못했습니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "MEMBER401_1", "비밀번호가 일치하지 않습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/example/umc/domain/member/exception/code/MemberSuccessCode.java
+++ b/src/main/java/com/example/umc/domain/member/exception/code/MemberSuccessCode.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 public enum MemberSuccessCode implements BaseCode {
 
     MEMBER_CREATED(HttpStatus.CREATED, "MEMBER201_1", "성공적으로 사용자가 생성되었습니다."),
+    MEMBER_LOGIN_SUCCESS(HttpStatus.OK, "MEMBER200_1", "로그인에 성공했습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/example/umc/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/umc/domain/member/repository/MemberRepository.java
@@ -4,6 +4,9 @@ import com.example.umc.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberRepository extends JpaRepository<User, Long> {
+  Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/example/umc/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/example/umc/domain/member/service/MemberCommandService.java
@@ -6,4 +6,7 @@ import com.example.umc.domain.member.dto.MemberResDTO;
 public interface MemberCommandService {
     // 회원가입
     MemberResDTO.JoinDTO signup(MemberReqDTO.JoinDTO dto);
+
+    // 로그인
+    MemberResDTO.LoginDTO login(MemberReqDTO.LoginDTO dto);
 }

--- a/src/main/java/com/example/umc/domain/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/example/umc/domain/member/service/MemberCommandServiceImpl.java
@@ -3,6 +3,8 @@ package com.example.umc.domain.member.service;
 import com.example.umc.domain.member.converter.MemberConverter;
 import com.example.umc.domain.member.dto.MemberReqDTO;
 import com.example.umc.domain.member.dto.MemberResDTO;
+import com.example.umc.domain.member.exception.MemberException;
+import com.example.umc.domain.member.exception.code.MemberErrorCode;
 import com.example.umc.domain.member.repository.MemberRepository;
 import com.example.umc.domain.user.entity.User;
 import com.example.umc.domain.user.entity.UserPrefer;
@@ -11,7 +13,12 @@ import com.example.umc.domain.category.entity.PreferCategory;
 import com.example.umc.domain.category.repository.PreferCategoryRepository;
 import com.example.umc.domain.category.exception.CategoryException;
 import com.example.umc.domain.category.exception.code.CategoryErrorCode;
+import com.example.umc.global.auth.CustomUserDetails;
+import com.example.umc.global.auth.JwtUtil;
+import com.example.umc.global.auth.Role;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,12 +32,17 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     private final MemberRepository memberRepository;
     private final UserPreferRepository userPreferRepository;
     private final PreferCategoryRepository preferCategoryRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
 
     @Override
     @Transactional
     public MemberResDTO.JoinDTO signup(MemberReqDTO.JoinDTO dto) {
+
+        // 비밀번호 암호화
+        String salt = passwordEncoder.encode(dto.password());
         // 사용자 생성
-        User member = MemberConverter.toMember(dto);
+        User member = MemberConverter.toMember(dto, salt, Role.ROLE_USER);
 
         // DB 적용
         memberRepository.save(member);
@@ -57,5 +69,27 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
         // 응답 DTO 생성
         return MemberConverter.toJoinDTO(member);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public MemberResDTO.LoginDTO login(@Valid MemberReqDTO.LoginDTO dto) {
+        // User 조회
+        User user = memberRepository.findByEmail(dto.email())
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        // 비밀번호 검증
+        if (!passwordEncoder.matches(dto.password(), user.getPassword())) {
+            throw new MemberException(MemberErrorCode.INVALID_PASSWORD);
+        }
+
+        // JWT 토큰 발급용 UserDetails
+        CustomUserDetails userDetails = new CustomUserDetails(user);
+
+        // 엑세스 토큰 발급
+        String accessToken = jwtUtil.createAccessToken(userDetails);
+
+        // DTO 조립
+        return MemberConverter.toLoginDTO(user, accessToken);
     }
 }

--- a/src/main/java/com/example/umc/domain/user/entity/User.java
+++ b/src/main/java/com/example/umc/domain/user/entity/User.java
@@ -9,6 +9,7 @@ import com.example.umc.domain.mission.entity.UserMission;
 import com.example.umc.domain.review.entity.Review;
 import com.example.umc.domain.notification.entity.Notification;
 import com.example.umc.global.common.BaseEntity;
+import com.example.umc.global.auth.Role;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -66,6 +67,12 @@ public class User extends BaseEntity {
 
   @Column(name = "email", length = 255)
   private String email;
+
+  @Column(nullable = false)
+  private String password;
+
+  @Enumerated(EnumType.STRING)
+  private Role role;
 
   @Column(name = "phone", length = 100)
   private String phone;

--- a/src/main/java/com/example/umc/global/auth/AuthenticationEntryPointImpl.java
+++ b/src/main/java/com/example/umc/global/auth/AuthenticationEntryPointImpl.java
@@ -1,0 +1,31 @@
+package com.example.umc.global.auth;
+
+import com.example.umc.global.apiPayload.ApiResponse;
+import com.example.umc.global.apiPayload.code.status.ErrorStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Override
+  public void commence(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      AuthenticationException authException) throws IOException {
+    response.setContentType("application/json;charset=UTF-8");
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+    ApiResponse<Void> errorResponse = ApiResponse.onFailure(
+        ErrorStatus._UNAUTHORIZED.getReasonHttpStatus().getCode(),
+        ErrorStatus._UNAUTHORIZED.getReasonHttpStatus().getMessage(),
+        null);
+
+    objectMapper.writeValue(response.getOutputStream(), errorResponse);
+  }
+}

--- a/src/main/java/com/example/umc/global/auth/CustomUserDetails.java
+++ b/src/main/java/com/example/umc/global/auth/CustomUserDetails.java
@@ -1,0 +1,54 @@
+package com.example.umc.global.auth;
+
+import com.example.umc.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+  private final User user;
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return List.of(() -> user.getRole().toString());
+  }
+
+  @Override
+  public String getPassword() {
+    return user.getPassword();
+  }
+
+  @Override
+  public String getUsername() {
+    return user.getEmail();
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return true;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return user.getUserStatus().name().equals("ACTIVE");
+  }
+
+  public User getUser() {
+    return user;
+  }
+}

--- a/src/main/java/com/example/umc/global/auth/CustomUserDetailsService.java
+++ b/src/main/java/com/example/umc/global/auth/CustomUserDetailsService.java
@@ -1,0 +1,26 @@
+package com.example.umc.global.auth;
+
+import com.example.umc.domain.member.repository.MemberRepository;
+import com.example.umc.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+  private final MemberRepository memberRepository;
+
+  @Override
+  public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    // 검증할 Member 조회
+    User user = memberRepository.findByEmail(username)
+        .orElseThrow(() -> new UsernameNotFoundException("해당 사용자를 찾지 못했습니다."));
+
+    // CustomUserDetails 반환
+    return new CustomUserDetails(user);
+  }
+}

--- a/src/main/java/com/example/umc/global/auth/JwtAuthFilter.java
+++ b/src/main/java/com/example/umc/global/auth/JwtAuthFilter.java
@@ -1,0 +1,55 @@
+package com.example.umc.global.auth;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+  private final JwtUtil jwtUtil;
+  private final CustomUserDetailsService customUserDetailsService;
+
+  @Override
+  protected void doFilterInternal(
+      @NonNull HttpServletRequest request,
+      @NonNull HttpServletResponse response,
+      @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+    // 토큰 가져오기
+    String token = request.getHeader("Authorization");
+    // token이 없거나 Bearer가 아니면 넘기기
+    if (token == null || !token.startsWith("Bearer ")) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+    // Bearer이면 추출
+    token = token.replace("Bearer ", "");
+    // 토큰이 있는데 유효하지 않으면 401 에러 발생
+    if (!jwtUtil.isValid(token)) {
+      throw new BadCredentialsException("유효하지 않은 토큰입니다.");
+    }
+    // AccessToken 검증하기: 올바른 토큰이면
+    // 토큰에서 이메일 추출
+    String email = jwtUtil.getEmail(token);
+    // 인증 객체 생성: 이메일로 찾아온 뒤, 인증 객체 생성
+    UserDetails user = customUserDetailsService.loadUserByUsername(email);
+    Authentication auth = new UsernamePasswordAuthenticationToken(
+        user,
+        null,
+        user.getAuthorities());
+    // 인증 완료 후 SecurityContextHolder에 넣기
+    SecurityContextHolder.getContext().setAuthentication(auth);
+    filterChain.doFilter(request, response);
+  }
+}

--- a/src/main/java/com/example/umc/global/auth/JwtUtil.java
+++ b/src/main/java/com/example/umc/global/auth/JwtUtil.java
@@ -1,0 +1,93 @@
+package com.example.umc.global.auth;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Component
+public class JwtUtil {
+
+  private final SecretKey secretKey;
+  private final Duration accessExpiration;
+
+  public JwtUtil(
+      @Value("${jwt.secret}") String secret,
+      @Value("${jwt.expiration}") Long accessExpiration) {
+    this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    this.accessExpiration = Duration.ofMillis(accessExpiration);
+  }
+
+  // AccessToken 생성
+  public String createAccessToken(CustomUserDetails user) {
+    return createToken(user, accessExpiration);
+  }
+
+  /**
+   * 토큰에서 이메일 가져오기
+   *
+   * @param token 유저 정보를 추출할 토큰
+   * @return 유저 이메일을 토큰에서 추출합니다
+   */
+  public String getEmail(String token) {
+    try {
+      return getClaims(token).getPayload().getSubject(); // Parsing해서 Subject 가져오기
+    } catch (JwtException e) {
+      return null;
+    }
+  }
+
+  /**
+   * 토큰 유효성 확인
+   *
+   * @param token 유효한지 확인할 토큰
+   * @return True, False 반환합니다
+   */
+  public boolean isValid(String token) {
+    try {
+      getClaims(token);
+      return true;
+    } catch (JwtException e) {
+      return false;
+    }
+  }
+
+  // 토큰 생성
+  private String createToken(CustomUserDetails user, Duration expiration) {
+    Instant now = Instant.now();
+
+    // 인가 정보
+    String authorities = user.getAuthorities().stream()
+        .map(GrantedAuthority::getAuthority)
+        .collect(Collectors.joining(","));
+
+    return Jwts.builder()
+        .subject(user.getUsername()) // User 이메일을 Subject로
+        .claim("role", authorities)
+        .claim("email", user.getUsername())
+        .issuedAt(Date.from(now)) // 언제 발급한지
+        .expiration(Date.from(now.plus(expiration))) // 언제까지 유효한지
+        .signWith(secretKey) // sign할 Key
+        .compact();
+  }
+
+  // 토큰 정보 가져오기
+  private Jws<Claims> getClaims(String token) throws JwtException {
+    return Jwts.parser()
+        .verifyWith(secretKey)
+        .clockSkewSeconds(60)
+        .build()
+        .parseSignedClaims(token);
+  }
+}

--- a/src/main/java/com/example/umc/global/auth/Role.java
+++ b/src/main/java/com/example/umc/global/auth/Role.java
@@ -1,0 +1,5 @@
+package com.example.umc.global.auth;
+
+public enum Role {
+  ROLE_ADMIN, ROLE_USER
+}

--- a/src/main/java/com/example/umc/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/umc/global/config/SecurityConfig.java
@@ -1,36 +1,84 @@
 package com.example.umc.global.config;
 
+import com.example.umc.global.auth.AuthenticationEntryPointImpl;
+import com.example.umc.global.auth.CustomUserDetailsService;
+import com.example.umc.global.auth.JwtAuthFilter;
+import com.example.umc.global.auth.JwtUtil;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+  private final CustomUserDetailsService customUserDetailsService;
+  private final JwtUtil jwtUtil;
+
+  private String[] allowUris = {
+      "/api/v1/reviews/**",
+      "/api/v1/stores/**",
+      "/api/v1/missions/**",
+      "/api/v1/members/**",
+      "/temp/**",
+      "/swagger-ui/**",
+      "/v3/api-docs/**",
+  };
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http
         .csrf(AbstractHttpConfigurer::disable)
         .authorizeHttpRequests(authz -> authz
-            // API 경로 허용
-            .requestMatchers("/api/v1/reviews/**").permitAll()
-            .requestMatchers("/api/v1/stores/**").permitAll()
-            .requestMatchers("/api/v1/missions/**").permitAll()
-            .requestMatchers("/api/v1/members/**").permitAll()
-            .requestMatchers("/temp/**").permitAll()
-            .requestMatchers("/swagger-ui/**").permitAll()
-            .requestMatchers("/v3/api-docs/**").permitAll()
-            .requestMatchers("/swagger-ui.html").permitAll()
-            .requestMatchers("/actuator/**").permitAll()
-            // 나머지는 인증 필요
+            .requestMatchers(allowUris).permitAll()
+            .requestMatchers("/admin/**").hasRole("ADMIN")
             .anyRequest().authenticated())
         .httpBasic(AbstractHttpConfigurer::disable)
-        .formLogin(AbstractHttpConfigurer::disable);
+        .formLogin(AbstractHttpConfigurer::disable)
+        .logout(logout -> logout
+            .logoutUrl("/logout")
+            .logoutSuccessUrl("/login?logout")
+            .permitAll())
+        .addFilterBefore(
+            jwtAuthFilter(),
+            UsernamePasswordAuthenticationFilter.class)
+        .exceptionHandling(exception -> exception
+            .authenticationEntryPoint(authenticationEntryPoint()));
 
     return http.build();
+  }
+
+  @Bean
+  public JwtAuthFilter jwtAuthFilter() {
+    return new JwtAuthFilter(jwtUtil, customUserDetailsService);
+  }
+
+  @Bean
+  public AuthenticationEntryPoint authenticationEntryPoint() {
+    return new AuthenticationEntryPointImpl();
+  }
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+
+  @Bean
+  public AuthenticationManager authenticationManager() {
+    DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider(passwordEncoder());
+    authProvider.setUserDetailsService(customUserDetailsService);
+    return new ProviderManager(authProvider);
   }
 }


### PR DESCRIPTION
### 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
closed #14 

### 작업한 내용
<!-- 작업한 내용을 적어주세요 -->

## 실습 1: Session 방식 구현

### 1. SecurityConfig 설정

Session 방식을 사용하기 위해 `SecurityConfig`에서 다음과 같이 설정:

```java
@Bean
public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
    http
        .csrf(AbstractHttpConfigurer::disable)
        .authorizeHttpRequests(authz -> authz
            .requestMatchers(allowUris).permitAll()
            .requestMatchers("/admin/**").hasRole("ADMIN")
            .anyRequest().authenticated())
        .formLogin(form -> form
            .loginProcessingUrl("/api/v1/members/login")
            .passwordParameter("password")
            .successHandler(loginSuccessHandler())
            .failureHandler(loginFailureHandler())
            .permitAll())
        .logout(logout -> logout
            .logoutUrl("/api/v1/members/logout")
            .logoutSuccessUrl("/login?logout")
            .permitAll());
    
    return http.build();
}
```

**주요 설정 내용**:
- `formLogin()`: Spring Security의 기본 폼 로그인 활성화
- `loginProcessingUrl()`: 로그인 처리 URL을 `/api/v1/members/login`으로 설정
- `logout()`: 로그아웃 URL 및 성공 후 리다이렉트 URL 설정

### 2. 로그인 서비스 구현

Session 방식에서는 `AuthenticationManager`를 사용하여 인증을 처리하고, Spring Security가 자동으로 세션 생성:

```java
@Override
@Transactional(readOnly = true)
public MemberResDTO.LoginDTO login(@Valid MemberReqDTO.LoginDTO dto) {
    // AuthenticationManager로 인증 처리
    Authentication authentication = authenticationManager.authenticate(
        new UsernamePasswordAuthenticationToken(dto.email(), dto.password())
    );
    
    // SecurityContext에 저장 (Session에도 자동 저장됨)
    SecurityContextHolder.getContext().setAuthentication(authentication);
    
    // User 조회
    User user = memberRepository.findByEmail(dto.email())
        .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
    
    // Session 방식이므로 토큰 없이 사용자 정보만 반환
    return MemberConverter.toLoginDTO(user);
}
```

**동작 과정**:
1. `AuthenticationManager.authenticate()` 호출
2. `CustomUserDetailsService`에서 사용자 조회
3. `PasswordEncoder`로 비밀번호 검증
4. 인증 성공 시 `Authentication` 객체 생성
5. `SecurityContextHolder`에 저장 → 자동으로 HttpSession에도 저장됨
6. 클라이언트에 `JSESSIONID` 쿠키 발급

### 3. 로그아웃 구현

서버 측 세션 무효화:

```java
@PostMapping("/logout")
@Operation(summary = "로그아웃", description = "현재 세션을 종료합니다.")
public ApiResponse<Void> logout(HttpServletRequest request, HttpServletResponse response) {
    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
    if (auth != null) {
        new SecurityContextLogoutHandler().logout(request, response, auth);
    }
    return ApiResponse.onSuccess(MemberSuccessCode.MEMBER_LOGOUT_SUCCESS, null);
}
```

**동작 과정**:
1. 현재 `SecurityContext`에서 `Authentication` 객체 가져오기
2. `SecurityContextLogoutHandler.logout()` 호출
3. HttpSession 무효화
4. `JSESSIONID` 쿠키 삭제

### 4. 회원가입 구현

Session 방식과 JWT 방식 모두 동일하게 구현:

```java
@Override
@Transactional
public MemberResDTO.JoinDTO signup(MemberReqDTO.JoinDTO dto) {
    // 비밀번호 암호화 (BCrypt 사용)
    String encodedPassword = passwordEncoder.encode(dto.password());
    
    // 사용자 생성
    User member = MemberConverter.toMember(dto, encodedPassword, Role.ROLE_USER);
    
    // DB 저장
    memberRepository.save(member);
    
    // 선호 카테고리 저장 (있는 경우)
    if (dto.preferCategory() != null && dto.preferCategory().size() > 0) {
        // ... 선호 카테고리 저장 로직
    }
    
    return MemberConverter.toJoinDTO(member);
}
```

**비밀번호 처리**:
- `BCryptPasswordEncoder`를 사용하여 비밀번호를 해시
- BCrypt는 자동으로 랜덤 솔트를 생성하고 해시 결과에 포함
- DB에는 해시된 비밀번호만 저장 (예: `$2a$10$...`)

### 5. DB 저장 확인

회원가입 후 `users` 테이블을 확인하면:
- `password` 컬럼에 BCrypt 해시 값이 저장됨
- 원본 비밀번호는 저장되지 않음
- `created_at`, `updated_at`은 JPA Auditing으로 자동 설정됨

---

## 실습 2: JWT 방식 구현

### 1. SecurityConfig 설정

JWT 방식을 사용하기 위해 `SecurityConfig`에서 다음과 같이 설정:

```java
@Bean
public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
    http
        .csrf(AbstractHttpConfigurer::disable)
        .authorizeHttpRequests(authz -> authz
            .requestMatchers(allowUris).permitAll()
            .requestMatchers("/admin/**").hasRole("ADMIN")
            .anyRequest().authenticated())
        .httpBasic(AbstractHttpConfigurer::disable)
        .formLogin(AbstractHttpConfigurer::disable)  // 폼 로그인 비활성화
        .logout(logout -> logout
            .logoutUrl("/logout")
            .logoutSuccessUrl("/login?logout")
            .permitAll())
        .addFilterBefore(
            jwtAuthFilter(),  // JWT 필터 추가
            UsernamePasswordAuthenticationFilter.class)
        .exceptionHandling(exception -> exception
            .authenticationEntryPoint(authenticationEntryPoint()));  // 인증 실패 처리
    
    return http.build();
}
```

**주요 설정 내용**:
- `formLogin().disable()`: Session 기반 로그인 비활성화
- `addFilterBefore()`: `JwtAuthFilter`를 필터 체인에 추가
- `exceptionHandling()`: 인증 실패 시 커스텀 에러 응답 반환

### 2. JwtUtil 구현

JWT 토큰 생성 및 검증을 위한 유틸리티 클래스 구현:

```java
@Component
public class JwtUtil {
    private final SecretKey secretKey;
    private final Duration accessExpiration;
    
    // AccessToken 생성
    public String createAccessToken(CustomUserDetails user) {
        Instant now = Instant.now();
        String authorities = user.getAuthorities().stream()
            .map(GrantedAuthority::getAuthority)
            .collect(Collectors.joining(","));
        
        return Jwts.builder()
            .subject(user.getUsername())  // 이메일
            .claim("role", authorities)
            .claim("email", user.getUsername())
            .issuedAt(Date.from(now))
            .expiration(Date.from(now.plus(accessExpiration)))  // 4시간
            .signWith(secretKey)
            .compact();
    }
    
    // 토큰 유효성 검증
    public boolean isValid(String token) {
        try {
            getClaims(token);
            return true;
        } catch (JwtException e) {
            return false;
        }
    }
    
    // 토큰에서 이메일 추출
    public String getEmail(String token) {
        try {
            return getClaims(token).getPayload().getSubject();
        } catch (JwtException e) {
            return null;
        }
    }
}
```

**설정 값**:
- `jwt.secret`: `90ee33b340aed322434e3b5b1b142b19` (HMAC SHA-256 키)
- `jwt.expiration`: `14400000` (4시간, 밀리초)

### 3. JwtAuthFilter 구현

모든 요청에 대해 JWT 토큰을 검증하는 필터 구현:

```java
@RequiredArgsConstructor
public class JwtAuthFilter extends OncePerRequestFilter {
    private final JwtUtil jwtUtil;
    private final CustomUserDetailsService customUserDetailsService;
    
    @Override
    protected void doFilterInternal(
        HttpServletRequest request,
        HttpServletResponse response,
        FilterChain filterChain) throws ServletException, IOException {
        
        // Authorization 헤더에서 토큰 추출
        String token = request.getHeader("Authorization");
        
        // 토큰이 없거나 Bearer 형식이 아니면 그냥 넘어감
        if (token == null || !token.startsWith("Bearer ")) {
            filterChain.doFilter(request, response);
            return;
        }
        
        // Bearer 제거
        token = token.replace("Bearer ", "");
        
        // 토큰이 있는데 유효하지 않으면 401 에러
        if (!jwtUtil.isValid(token)) {
            throw new BadCredentialsException("유효하지 않은 토큰입니다.");
        }
        
        // 유효한 토큰이면 사용자 정보 로드 및 인증 처리
        String email = jwtUtil.getEmail(token);
        UserDetails user = customUserDetailsService.loadUserByUsername(email);
        Authentication auth = new UsernamePasswordAuthenticationToken(
            user, null, user.getAuthorities());
        SecurityContextHolder.getContext().setAuthentication(auth);
        
        filterChain.doFilter(request, response);
    }
}
```

**동작 과정**:
1. `Authorization` 헤더에서 `Bearer {token}` 형식의 토큰 추출
2. 토큰이 없으면 그냥 넘어감 (인증이 필요한 경로는 나중에 Spring Security가 차단)
3. 토큰이 있지만 유효하지 않으면 `BadCredentialsException` 발생 → 401 반환
4. 유효한 토큰이면 이메일 추출 후 사용자 정보 로드
5. `SecurityContext`에 인증 정보 저장

### 4. AuthenticationEntryPointImpl 구현

인증 실패 시 커스텀 에러 응답을 반환하는 클래스 구현:

```java
public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
    private final ObjectMapper objectMapper = new ObjectMapper();
    
    @Override
    public void commence(
        HttpServletRequest request,
        HttpServletResponse response,
        AuthenticationException authException) throws IOException {
        
        response.setContentType("application/json;charset=UTF-8");
        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
        
        ApiResponse<Void> errorResponse = ApiResponse.onFailure(
            ErrorStatus._UNAUTHORIZED.getReasonHttpStatus().getCode(),
            ErrorStatus._UNAUTHORIZED.getReasonHttpStatus().getMessage(),
            null);
        
        objectMapper.writeValue(response.getOutputStream(), errorResponse);
    }
}
```

**동작**:
- `JwtAuthFilter`에서 발생한 `AuthenticationException`을 받아서 처리
- 일관된 형식의 에러 응답 반환

### 5. 로그인 서비스 구현

JWT 방식에서는 로그인 성공 시 토큰을 발급:

```java
@Override
@Transactional(readOnly = true)
public MemberResDTO.LoginDTO login(@Valid MemberReqDTO.LoginDTO dto) {
    // User 조회
    User user = memberRepository.findByEmail(dto.email())
        .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
    
    // 비밀번호 검증
    if (!passwordEncoder.matches(dto.password(), user.getPassword())) {
        throw new MemberException(MemberErrorCode.INVALID_PASSWORD);
    }
    
    // JWT 토큰 발급용 UserDetails 생성
    CustomUserDetails userDetails = new CustomUserDetails(user);
    
    // AccessToken 발급
    String accessToken = jwtUtil.createAccessToken(userDetails);
    
    // 토큰을 포함한 응답 반환
    return MemberConverter.toLoginDTO(user, accessToken);
}
```

**동작 과정**:
1. 이메일로 사용자 조회
2. 비밀번호 검증 (`passwordEncoder.matches()`)
3. `CustomUserDetails` 생성
4. JWT 토큰 발급
5. 사용자 정보와 토큰을 함께 반환

### 6. 로그인 응답 DTO

JWT 방식에서는 `accessToken`을 포함:

```java
@Builder
public record LoginDTO(
    Long memberId,
    String email,
    String name,
    Role role,
    String accessToken,  // JWT 토큰
    LocalDateTime createdAt
) {}
```

### 7. 회원가입 구현

JWT 방식과 Session 방식 모두 동일하게 구현 (비밀번호 해싱 방식 동일).

---

## 🔄 두 방식의 차이점

### Session 방식
- **서버 측 세션 저장**: HttpSession에 인증 정보 저장
- **쿠키 사용**: `JSESSIONID` 쿠키로 세션 식별
- **상태 유지**: 서버에서 세션 상태 관리 필요
- **확장성**: 서버 확장 시 세션 공유 필요 (Redis 등)
- **로그아웃**: 서버에서 세션 무효화 필요

### JWT 방식
- **Stateless**: 서버에 상태 저장 불필요
- **토큰 기반**: 클라이언트가 토큰 보관
- **확장성**: 서버 확장이 용이 (상태 없음)
- **토큰 만료**: 설정한 만료 시간(4시간) 후 자동 만료
- **로그아웃**: 클라이언트에서 토큰 삭제만 하면 됨 (또는 블랙리스트 구현)

---

## 📝 구현된 API 목록

### 공통 (Session/JWT 모두)
- `POST /api/v1/members/signup`: 회원가입
- `POST /api/v1/members/login`: 로그인

### Session 방식 전용
- `POST /api/v1/members/logout`: 로그아웃 (세션 무효화)

### JWT 방식
- 로그아웃은 클라이언트에서 토큰 삭제만 하면 됨

---

## 🎯 결론

두 가지 인증 방식을 모두 구현하여 각각의 특징과 장단점을 이해. Session 방식은 전통적이고 안정적이며, JWT 방식은 확장성이 좋고 Stateless한 구조를 제공. 프로젝트의 요구사항에 따라 적절한 방식을 선택할 수 있음.



### PR Point 및 참고사항, 스크린샷
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->